### PR TITLE
allow disputes from past sessions to be repartitioned

### DIFF
--- a/contracts/KlerosPOC.sol
+++ b/contracts/KlerosPOC.sol
@@ -290,8 +290,8 @@ contract KlerosPOC is Arbitrator {
     function oneShotTokenRepartition(uint _disputeID) public onlyDuring(Period.Execution) {
         Dispute storage dispute = disputes[_disputeID];
         require(dispute.state==DisputeState.Open);
-        require(dispute.session+dispute.appeals==session);
-        
+        require(dispute.session+dispute.appeals<=session);
+
         uint winningChoice=dispute.voteCounter[dispute.appeals].winningChoice;
         uint amountShift=(alpha*minActivatedToken)/ALPHA_DIVISOR;
         for (uint i=0;i<=dispute.appeals;++i) {


### PR DESCRIPTION
Security wise this change checks out. As disputes from past sessions are already final, either by way of having a decision or by jurors refusing to arbitrate, there is no vulnerability in repartitioning a past dispute. Disputes are unrelated so it will not effect current/future disputes to repartition tokens and execute a decision for a past dispute. The existing constraints of only repartitioning `Open` disputes in the `Execute` period ensure that tokens are not repartitioned before a decision is final and is not repartitioned more than once