### PR TITLE
Fix POCCourt calling struct's function

### DIFF
--- a/contracts/KlerosPOCCourt.sol
+++ b/contracts/KlerosPOCCourt.sol
@@ -45,7 +45,7 @@ contract KlerosPOCCourt is ArbitratorCourt, KlerosPOC {
 
             // Interactions
             Arbitrator.appeal(_disputeID, _extraData); // Fire appeal event
-            parent.createDispute.value(msg.value)(disputes[_disputeID].choices, _extraData); // Create dispute in `parent` court
+            parent._address.createDispute.value(msg.value)(disputes[_disputeID].choices, _extraData); // Create dispute in `parent` court
         }
     }
 
@@ -61,6 +61,6 @@ contract KlerosPOCCourt is ArbitratorCourt, KlerosPOC {
             return super.appealCost(_disputeID, _extraData); // Regular appeal cost
         }
 
-        return parent.arbitrationCost(_extraData); // `parent` arbitration cost
+        return parent._address.arbitrationCost(_extraData); // `parent` arbitration cost
     }
 }


### PR DESCRIPTION
`KlerosPOCCourt` currently tries to do this:
https://github.com/kleros/kleros/blob/4e3b2062e50072cea9af72b863a138164c2bed3f/contracts/KlerosPOCCourt.sol#L48
`parent` defined in `ArbitratorCourt` is of type `Court`, which is a struct defined in the same contract:
https://github.com/kleros/kleros-interaction/blob/05bc2ec7576efb8f375366d47eb5a44d1df3def3/contracts/standard/arbitration/ArbitratorCourt.sol#L13
`Court` has member `_address` which holds reference to actual Court contract. All functions trying to use this Court's functions should call them on `parent._address` instead of `parent` as the struct doesn't expose any functions on its own.