### PR TITLE
feat: add session number to NewPeriod event

### DIFF
--- a/contracts/Kleros.sol
+++ b/contracts/Kleros.sol
@@ -110,8 +110,9 @@ contract Kleros is Arbitrator, ApproveAndCallFallBack {
 
     /** @dev Emitted when we pass to a new period.
      *  @param _period The new period.
+     *  @param _session The current session.
      */
-    event NewPeriod(Period _period);
+    event NewPeriod(Period _period, uint _session);
 
     /** @dev Emitted when a juror wins or loses tokens.
       * @param _account The juror affected.
@@ -208,7 +209,7 @@ contract Kleros is Arbitrator, ApproveAndCallFallBack {
 
 
         lastPeriodChange=now;
-        NewPeriod(period);
+        NewPeriod(period, session);
     }
 
 

--- a/contracts/Kleros.sol
+++ b/contracts/Kleros.sol
@@ -112,7 +112,7 @@ contract Kleros is Arbitrator, ApproveAndCallFallBack {
      *  @param _period The new period.
      *  @param _session The current session.
      */
-    event NewPeriod(Period _period, uint _session);
+    event NewPeriod(Period _period, uint indexed _session);
 
     /** @dev Emitted when a juror wins or loses tokens.
       * @param _account The juror affected.


### PR DESCRIPTION
Having the session in the NewPeriod event log will make it easier to use the event.

The index on session will make it easy to look up when a session occurred.