### PR TITLE
Updates Truffle dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/kleros/kleros#readme",
   "devDependencies": {
-    "truffle": "^4.0.4",
+    "truffle": "^4.1.12",
     "web3": "^1.0.0-beta.22"
   },
   "dependencies": {


### PR DESCRIPTION
4.1.12 is the first version supports the new constructor() declaration