### PR TITLE
fix: constructor declaration

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    function constructor() public {
+    constructor() public {
         owner = msg.sender;
     }
 


### PR DESCRIPTION
> Warning: This function is named "constructor" but is not the constructor of the contract. If you intend this to be a constructor, use "constructor(...) { ... }" without the "function" keyword to define it.