### PR TITLE
fix: add missing NewPeriod event

### DIFF
--- a/contracts/kleros/KlerosLiquid.sol
+++ b/contracts/kleros/KlerosLiquid.sol
@@ -745,6 +745,7 @@ contract KlerosLiquid is TokenController, Arbitrator {
         disputesWithoutJurors++;
 
         emit AppealDecision(_disputeID, Arbitrable(msg.sender));
+        emit NewPeriod(_disputeID, Period.evidence);
     }
 
     /** @dev Called when `_owner` sends ether to the MiniMe Token contract.
@@ -946,7 +947,7 @@ contract KlerosLiquid is TokenController, Arbitrator {
             subcourtID := _stakePathID
         }
     }
-    
+
     /* Interface Views */
 
     /** @dev Gets a specified subcourt's non primitive properties.


### PR DESCRIPTION
`NewPeriod` should be emmited when an appeal is raised since the dispute period moves from `Period.Appeal` to `Period.Evidence`. Otherwise we can't use the `NewPeriod` event logs to reliably get the latest state of many disputes at once.