### PR TITLE
fix(kleros-governor): avoid arbitrary execution order

### DIFF
--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -301,18 +301,22 @@ contract KlerosGovernor is Arbitrable{
 
     /** @dev Executes selected transactions of the list.
      *  @param _listID The index of the transaction list in the array of lists.
-     *  @param _cursor Index of the transaction from which to start executing.
-     *  @param _count Number of transactions to execute. Executes until the end if set to "0" or number higher than number of transactions in the list.
+     *  @param _executeUpTo Threshold to stop execution. For example _executeUpTo=2 would make the function execute transactions [0, 1, 2]. The function executes all the transactions if this parameter is set to "0" or a number that is equal or greater than number of transactions in the list.
+     *  @return noOfExecutedTxs Returns number of executed transactions in the given list.
      */
-    function executeTransactionList(uint _listID, uint _cursor, uint _count) public {
+    function executeTransactionList(uint _listID, uint _executeUpTo) public returns (uint noOfExecutedTxs){
         TransactionList storage txList = txLists[_listID];
         require(txList.approved, "Can't execute list that wasn't approved");
-        for (uint i = _cursor; i < txList.txs.length && (_count == 0 || i < _cursor + _count) ; i++){
+        for (uint i = 0; i < txList.txs.length && (_executeUpTo == 0 || i < _executeUpTo) ; i++){
             Transaction storage transaction = txList.txs[i];
-            if (transaction.executed || transaction.value > address(this).balance) continue;
-            transaction.executed = true;
-            transaction.target.call.value(transaction.value)(transaction.data); // solium-disable-line security/no-call-value
+            if (transaction.executed) continue;
+            else if (transaction.value > address(this).balance) return i;
+            else transaction.executed = transaction.target.call.value(transaction.value)(transaction.data); // solium-disable-line security/no-call-value
+
+            if (!transaction.executed) return i;
         }
+
+        return txList.txs.length;
     }
 
     /** @dev Gets the info of the specified transaction in the specified list.

--- a/test/kleros/kleros-governor.js
+++ b/test/kleros/kleros-governor.js
@@ -727,7 +727,7 @@ contract('KlerosGovernor', function(accounts) {
 
     // The transaction should not be executed if list is not approved
     await expectThrow(
-      klerosgovernor.executeTransactionList(0, 0, 1, { from: general })
+      klerosgovernor.executeTransactionList(0, 1, { from: general })
     )
 
     await increaseTime(submissionTimeout + 1)
@@ -741,7 +741,7 @@ contract('KlerosGovernor', function(accounts) {
     })
 
     // Execute the first and the second transactions separately to check atomic execution.
-    await klerosgovernor.executeTransactionList(0, 0, 1, { from: general })
+    await klerosgovernor.executeTransactionList(0, 1, { from: general })
 
     const dispute = await arbitrator.disputes(0)
     assert.equal(
@@ -775,7 +775,7 @@ contract('KlerosGovernor', function(accounts) {
       'WithdrawTimeout before execution is incorrect'
     )
 
-    await klerosgovernor.executeTransactionList(0, 1, 1, { from: general })
+    await klerosgovernor.executeTransactionList(0, 2, { from: general })
 
     withdrawTime = await klerosgovernor.withdrawTimeout()
     assert.equal(
@@ -813,7 +813,7 @@ contract('KlerosGovernor', function(accounts) {
       value: submissionDeposit
     })
 
-    await klerosgovernor.executeTransactionList(0, 0, 0, { from: general })
+    await klerosgovernor.executeTransactionList(0, 0, { from: general })
 
     const dispute = await arbitrator.disputes(0)
     assert.equal(


### PR DESCRIPTION
We should not let executing transactions in an arbitrary order because subsequent transactions may depend on previous transactions post-conditions.