### PR TITLE
refactor(kleros-liquid): let arbitrable to pass appeal period earlier

### DIFF
--- a/contracts/kleros/KlerosLiquid.sol
+++ b/contracts/kleros/KlerosLiquid.sol
@@ -432,6 +432,7 @@ contract KlerosLiquid is TokenController, Arbitrator {
             dispute.period = Period.appeal;
             emit AppealPossible(_disputeID, dispute.arbitrated);
         } else if (dispute.period == Period.appeal) {
+            if(Arbitrable(msg.sender) != disputes[_disputeID].arbitrated)
             require(now - dispute.lastPeriodChange >= courts[dispute.subcourtID].timesPerPeriod[uint(dispute.period)], "The appeal period time has not passed yet.");
             dispute.period = Period.execution;
         } else if (dispute.period == Period.execution) {

--- a/test/kleros/kleros-liquid.js
+++ b/test/kleros/kleros-liquid.js
@@ -636,7 +636,7 @@ contract('KlerosLiquid', accounts => {
       numberOfJurors - 1
     )
     await klerosLiquid.passPeriod(disputeID)
-    await expectThrow(klerosLiquid.passPeriod(disputeID))
+    await expectThrow(klerosLiquid.passPeriod(disputeID, { from: accounts[5] }))
     await increaseTime(subcourtTree.timesPerPeriod[3])
     await klerosLiquid.passPeriod(disputeID)
     await expectThrow(klerosLiquid.passPeriod(disputeID))


### PR DESCRIPTION
Let arbitrable to pass appeal period earlier to avoid unnecessary wait when loser didn't pay the appeal fee in the given time (usually shorter than appeal period).