### PR TITLE
fix(KlerosGovernor): set meta evidence outside constructor

### DIFF
--- a/test/kleros/kleros-governor.js
+++ b/test/kleros/kleros-governor.js
@@ -56,9 +56,10 @@ contract('KlerosGovernor', function(accounts) {
       sharedMultiplier,
       winnerMultiplier,
       loserMultiplier,
-      metaEvidenceURI,
       { from: general }
     )
+
+    await klerosgovernor.setMetaEvidence(metaEvidenceURI, { from: general })
   })
 
   it('Should set correct values in constructor', async () => {


### PR DESCRIPTION
- Meta Evidence needs to be set outside constructor for dynamicScript.
- View function to get number of rounds in a session for crowdfunding.