### PR TITLE
Matts review of Kleros Governor

### DIFF
--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -571,8 +571,8 @@ contract KlerosGovernor is Arbitrable {
         return submissions.length;
     }
 
-    /** @dev Gets the number of ongoing session.
-     *  @return The number of ongoing sessions.
+    /** @dev Gets the number of the ongoing session.
+     *  @return The number of the ongoing session.
      */
     function getCurrentSessionNumber() public view returns (uint){
         return sessions.length - 1;

--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -1,6 +1,6 @@
 /**
  *  @authors: [@unknownunknown1]
- *  @reviewers: [@ferittuncer, @clesaege]
+ *  @reviewers: [@ferittuncer, @clesaege, @mtsalenc]
  *  @auditors: []
  *  @bounties: []
  *  @deployments: []

--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -26,10 +26,10 @@ contract KlerosGovernor is Arbitrable{
 
     struct Session {
         Round[] rounds; // Tracks each appeal round of a dispute.
-        uint ruling; // The ruling that was given in this session.
-        uint disputeID; // ID given to the dispute of the session.
+        uint ruling; // The ruling that was given in this session, if any.
+        uint disputeID; // ID given to the dispute of the session, if any.
         uint[] submittedLists; // Tracks all lists that were submitted in a session. submittedLists[submissionID].
-        uint sumDeposit; // Sum of all submission deposits in a session (minus arbitration fees). Is needed for calculating a reward.
+        uint sumDeposit; // Sum of all submission deposits in a session (minus arbitration fees). This is used to calculate the reward.
         Status status; // Status of a session.
         mapping(bytes32 => bool) alreadySubmitted; // Indicates whether or not the transaction list was already submitted in order to catch duplicates. alreadySubmitted[listHash].
     }
@@ -40,12 +40,13 @@ contract KlerosGovernor is Arbitrable{
         bytes data; // Calldata of the transaction.
         bool executed; // Whether the transaction was already executed or not.
     }
+
     struct Submission {
         address submitter; // The one who submits the list.
-        uint deposit; // Value of a deposit paid upon submission of the list.
+        uint deposit; // Value of the deposit paid upon submission of the list.
         Transaction[] txs; // Transactions stored in the list. txs[_transactionIndex].
-        bytes32 listHash; // A hash chain of all transactions stored in the list. Is used for catching duplicates.
-        uint submissionTime; // Time the list was submitted.
+        bytes32 listHash; // A hash chain of all transactions stored in the list. This is used to catch duplicates.
+        uint submissionTime; // The time when the list was submitted.
         bool approved; // Whether the list was approved for execution or not.
     }
 
@@ -57,7 +58,7 @@ contract KlerosGovernor is Arbitrable{
         uint successfullyPaid; // Sum of all successfully paid fees paid by all sides.
     }
 
-    uint constant NO_SHADOW_WINNER = uint(-1); // The value that indicates that no one has successfully paid appeal fees in a current round. It's -1 and not 0, because 0 can be a valid submission index.
+    uint constant NO_SHADOW_WINNER = uint(-1); // The value that indicates that no one has successfully paid appeal fees in a current round. It's the largest integer and not 0, because 0 can be a valid submission index.
 
     address public deployer; // The address of the deployer of the contract.
 

--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -9,7 +9,7 @@
 /* solium-disable security/no-block-members */
 /* solium-disable max-len*/
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.4.26;
 
 import "@kleros/kleros-interaction/contracts/standard/arbitration/Arbitrable.sol";
 import "@kleros/kleros-interaction/contracts/libraries/CappedMath.sol";

--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -18,7 +18,7 @@ import "@kleros/kleros-interaction/contracts/libraries/CappedMath.sol";
  *  Note that this contract trusts that the Arbitrator is honest and will not re-enter or modify its costs during a call.
  *  Also note that tx.origin should not matter in contracts called by the governor.
  */
-contract KlerosGovernor is Arbitrable{
+contract KlerosGovernor is Arbitrable {
     using CappedMath for uint;
 
     /* *** Contract variables *** */
@@ -86,7 +86,7 @@ contract KlerosGovernor is Arbitrable{
     /* *** Events *** */
     /** @dev Emitted when a new list is submitted.
      *  @param _listID The index of the transaction list in the array of lists.
-     *  @param _submitter The one who submitted the list.
+     *  @param _submitter The address that submitted the list.
      *  @param _session The number of the current session.
      *  @param _description The string in CSV format that contains labels of list's transactions.
      *  Note that the submitter may give bad descriptions of correct actions, but this is to be seen as UI enhancement, not a critical feature and that would play against him in case of dispute.
@@ -135,21 +135,21 @@ contract KlerosGovernor is Arbitrable{
     }
 
     /** @dev Changes the value of the deposit required for submitting a list.
-     *  @param _submissionDeposit The new value of a required deposit. In wei.
+     *  @param _submissionDeposit The new value of the deposit, in wei. Note that this value should be higher than arbitration cost.
      */
     function changeSubmissionDeposit(uint _submissionDeposit) public onlyByGovernor {
         submissionDeposit = _submissionDeposit;
     }
 
     /** @dev Changes the time allocated for submission.
-     *  @param _submissionTimeout The new duration of submission time. In seconds.
+     *  @param _submissionTimeout The new duration of the submission period, in seconds.
      */
     function changeSubmissionTimeout(uint _submissionTimeout) public onlyByGovernor duringSubmissionPeriod {
         submissionTimeout = _submissionTimeout;
     }
 
     /** @dev Changes the time allowed for list withdrawal.
-     *  @param _withdrawTimeout The new duration of withdraw timeout. In seconds.
+     *  @param _withdrawTimeout The new duration of withdraw period, in seconds.
      */
     function changeWithdrawTimeout(uint _withdrawTimeout) public onlyByGovernor {
         withdrawTimeout = _withdrawTimeout;
@@ -572,7 +572,7 @@ contract KlerosGovernor is Arbitrable{
     }
 
     /** @dev Gets the number of ongoing session.
-     *  @return The number of ongoing session.
+     *  @return The number of ongoing session or the maximum unsined integer if no sessions were ever submitted.
      */
     function getCurrentSessionNumber() public view returns (uint){
         return sessions.length - 1;

--- a/contracts/kleros/KlerosGovernor.sol
+++ b/contracts/kleros/KlerosGovernor.sol
@@ -572,7 +572,7 @@ contract KlerosGovernor is Arbitrable {
     }
 
     /** @dev Gets the number of ongoing session.
-     *  @return The number of ongoing session or the maximum unsined integer if no sessions were ever submitted.
+     *  @return The number of ongoing sessions.
      */
     function getCurrentSessionNumber() public view returns (uint){
         return sessions.length - 1;


### PR DESCRIPTION
Currently, it is the responsability of the governor to ensure that `submissionDeposit` is higher than the arbitration cost. I believe this is not optimal, since it requires updating `submissionDeposit` any time the arbitration cost increases above it. Seems like people could forget about this.

Instead, I propose we update the `submitList` function to accept any amount greater than `submissionDeposit + arbitrationCost` and reimburse unused funds.